### PR TITLE
Clarify and expand documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # tokio-rustls
-[![crates](https://img.shields.io/crates/v/tokio-rustls.svg)](https://crates.io/crates/tokio-rustls)
-[![license](https://img.shields.io/github/license/quininer/tokio-rustls.svg)](https://github.com/quininer/tokio-rustls/blob/master/LICENSE)
-[![docs.rs](https://docs.rs/tokio-rustls/badge.svg)](https://docs.rs/tokio-rustls/)
+[![crates](https://img.shields.io/crates/v/tokio-rustls.svg)](https://crates.io/crates/tokio-rustls) [![license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/quininer/tokio-rustls/blob/master/LICENSE-MIT) [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/quininer/tokio-rustls/blob/master/LICENSE-APACHE) [![docs.rs](https://docs.rs/tokio-rustls/badge.svg)](https://docs.rs/tokio-rustls/)
 
-[tokio-tls](https://github.com/tokio-rs/tokio-tls) fork, use [rustls](https://github.com/ctz/rustls).
+Asynchronous TLS/SSL streams for [Tokio](https://tokio.rs/) using
+[Rustls](https://github.com/ctz/rustls).
 
-### exmaple
+### Basic Structure of a Client
 
 ```rust
 // ...
@@ -22,3 +21,27 @@ TcpStream::connect(&addr, &handle)
 
 // ...
 ```
+
+### Client Example Program
+
+See [examples/client.rs](examples/client.rs). You can run it with:
+
+```sh
+cargo run --example client google.com
+```
+
+### Server Example Program
+
+See [examples/server.rs](examples/server.rs). You can run it with:
+
+```sh
+cargo run --example server -- 127.0.0.1 --cert mycert.der --key mykey.der
+```
+
+### License & Origin
+
+tokio-rustls is primarily distributed under the terms of both the [MIT license](LICENSE-MIT) and
+the [Apache License (Version 2.0)](LICENSE-APACHE), with portions covered by various BSD-like
+licenses.
+
+This started as a fork of [tokio-tls](https://github.com/tokio-rs/tokio-tls).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
-//! Async TLS streams
-//!
-//! [tokio-tls](https://github.com/tokio-rs/tokio-tls) fork, use [rustls](https://github.com/ctz/rustls).
+//! Asynchronous TLS/SSL streams for Tokio using [Rustls](https://github.com/ctz/rustls).
+
 
 #[cfg_attr(feature = "tokio-proto", macro_use)] extern crate futures;
 extern crate tokio_io;


### PR DESCRIPTION
This fixes some typos, adds some more links, and expands the documentation to point to the full examples.