### PR TITLE
0.2.0: Update Rustls and webpki-roots versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rustls"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["quininer kel <quininer@live.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/quininer/tokio-rustls"
@@ -13,13 +13,13 @@ categories = ["asynchronous", "cryptography", "network-programming"]
 [dependencies]
 futures = "0.1"
 tokio-io = "0.1"
-rustls = "0.5"
+rustls = "0.7"
 tokio-proto = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio-core = "0.1"
 clap = "2.20"
-webpki-roots = "0.7"
+webpki-roots = "0.10.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 tokio-file-unix = "0.2"


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another dependend on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

The versions of Rustls and webpki-roots listed here will correctly pull in *ring* 0.9.3 or later because they depend on the webpki crate which requires 0.9.4.