### PR TITLE
upgrade rustls to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "cryptography", "network-programming"]
 [dependencies]
 futures = "0.1"
 tokio-io = "0.1"
-rustls = "0.7"
+rustls = "0.8"
 tokio-proto = { version = "0.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This is required for the larger upgrade process going on with *ring*