### PR TITLE
Allowing to use custom sessions to build async connector/acceptor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,10 @@ impl<S, C> io::Write for TlsStream<S, C>
     where S: AsyncRead + AsyncWrite, C: Session
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.len() == 0 {
+            return Ok(0);
+        }
+
         loop {
             let output = self.session.write(buf)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,15 @@ impl ClientConfigExt for Arc<ClientConfig> {
     }
 }
 
+pub fn connect_async_with_session<S>(stream: S, session: ClientSession)
+    -> ConnectAsync<S>
+    where S: AsyncRead + AsyncWrite
+{
+    ConnectAsync(MidHandshake {
+        inner: Some(TlsStream::new(stream, session))
+    })
+}
+
 impl ServerConfigExt for Arc<ServerConfig> {
     fn accept_async<S>(&self, stream: S)
         -> AcceptAsync<S>
@@ -61,6 +70,15 @@ impl ServerConfigExt for Arc<ServerConfig> {
             inner: Some(TlsStream::new(stream, ServerSession::new(self)))
         })
     }
+}
+
+pub fn accept_async_with_session<S>(stream: S, session: ServerSession)
+    -> AcceptAsync<S>
+    where S: AsyncRead + AsyncWrite
+{
+    AcceptAsync(MidHandshake {
+        inner: Some(TlsStream::new(stream, session))
+    })
 }
 
 impl<S: AsyncRead + AsyncWrite> Future for ConnectAsync<S> {


### PR DESCRIPTION
Solve #9 by adding two public methods `connect_async_with_session` and `accept_async_with_session` in mod tokio_rustls.