### PR TITLE
0.4.0: Use rustls 0.11, webpki-roots 0.13, and update other deps.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rustls"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["quininer kel <quininer@live.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/quininer/tokio-rustls"
@@ -18,15 +18,15 @@ appveyor = { repository = "quininer/tokio-rustls" }
 danger = [ "rustls/dangerous_configuration" ]
 
 [dependencies]
-futures = "0.1"
-tokio-io = "0.1"
-rustls = "0.10"
-tokio-proto = { version = "0.1", optional = true }
+futures = "0.1.15"
+tokio-io = "0.1.3"
+rustls = "0.11"
+tokio-proto = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
-tokio-core = "0.1"
-clap = "2.20"
-webpki-roots = "0.12"
+tokio-core = "0.1.9"
+clap = "2.26"
+webpki-roots = "0.13"
 
 [target.'cfg(unix)'.dev-dependencies]
 tokio-file-unix = "0.4"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use tokio_rustls::ClientConfigExt;
 // ...
 
 let mut config = ClientConfig::new();
-config.root_store.add_trust_anchors(&webpki_roots::ROOTS);
+config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 let config = Arc::new(config);
 
 TcpStream::connect(&addr, &handle)

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -64,7 +64,7 @@ fn main() {
         let mut pem = BufReader::new(fs::File::open(cafile).unwrap());
         config.root_store.add_pem_file(&mut pem).unwrap();
     } else {
-        config.root_store.add_trust_anchors(&webpki_roots::ROOTS);
+        config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     }
     let arc_config = Arc::new(config);
 


### PR DESCRIPTION
This won't build until Rustls 0.11 is released, which is being tracked here: https://github.com/ctz/rustls/pull/99