### PR TITLE
List `tokio-proto` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 description = "Asynchronous TLS/SSL streams for Tokio using Rustls."
 categories = ["asynchronous", "cryptography", "network-programming"]
 
+[features]
+tokio-proto = []
+
 [badges]
 travis-ci = { repository = "quininer/tokio-rustls" }
 appveyor = { repository = "quininer/tokio-rustls" }


### PR DESCRIPTION
Without it, [`cargo-outdated`](https://github.com/kbknapp/cargo-outdated) shows the feature is outdated i.e. doesn’t exist. With it, I hope not. It surely doesn’t hurt to make the feature explicit.