### PR TITLE
Reexport deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Asynchronous TLS/SSL streams for [Tokio](https://tokio.rs/) using
 
 ```rust
 use webpki::DNSNameRef;
-use rustls::ClientConfig;
-use tokio_rustls::ClientConfigExt;
+use tokio_rustls::{ClientConfigExt, rustls::ClientConfig};
 
 // ...
 

--- a/examples/client/Cargo.toml
+++ b/examples/client/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["quininer <quininer@live.com>"]
 
 [dependencies]
-rustls = "0.13"
 webpki = "0.18.1"
 tokio-rustls = { path = "../..", default-features = false, features = [ "tokio" ] }
 

--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -1,5 +1,4 @@
 extern crate clap;
-extern crate rustls;
 extern crate tokio;
 extern crate webpki;
 extern crate webpki_roots;
@@ -16,8 +15,7 @@ use tokio::io;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 use clap::{ App, Arg };
-use rustls::ClientConfig;
-use tokio_rustls::ClientConfigExt;
+use tokio_rustls::{ClientConfigExt, rustls::ClientConfig};
 
 fn app() -> App<'static, 'static> {
     App::new("client")

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["quininer <quininer@live.com>"]
 
 [dependencies]
-rustls = "0.13"
 tokio-rustls = { path = "../..", default-features = false, features = [ "tokio" ] }
 
 tokio = { version = "0.1.6" }

--- a/examples/server/src/main.rs
+++ b/examples/server/src/main.rs
@@ -1,5 +1,4 @@
 extern crate clap;
-extern crate rustls;
 extern crate tokio;
 extern crate tokio_rustls;
 
@@ -7,14 +6,15 @@ use std::sync::Arc;
 use std::net::ToSocketAddrs;
 use std::io::BufReader;
 use std::fs::File;
-use rustls::{ Certificate, NoClientAuth, PrivateKey, ServerConfig };
-use rustls::internal::pemfile::{ certs, rsa_private_keys };
+use tokio_rustls::{
+    ServerConfigExt,
+    rustls::{ Certificate, NoClientAuth, PrivateKey, ServerConfig,
+    internal::pemfile::{ certs, rsa_private_keys }},
+};
 use tokio::prelude::{ Future, Stream };
 use tokio::io::{ self, AsyncRead };
 use tokio::net::TcpListener;
 use clap::{ App, Arg };
-use tokio_rustls::ServerConfigExt;
-
 
 fn app() -> App<'static, 'static> {
     App::new("server")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Asynchronous TLS/SSL streams for Tokio using [Rustls](https://github.com/ctz/rustls).
 
-extern crate rustls;
-extern crate webpki;
+pub extern crate rustls;
+pub extern crate webpki;
 
 #[cfg(feature = "tokio")] mod tokio_impl;
 #[cfg(feature = "unstable-futures")] mod futures_impl;


### PR DESCRIPTION
This helps encapsulate deps and match crate versions for downstream use. I have a need for this already, since I’m getting compilation errors:
```
    = note: expected type `rustls::server::ServerConfig`
               found type `rustls::ServerConfig`
note: Perhaps two different versions of crate `rustls` are being used?

```