### PR TITLE
Shrink down the dependency on tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ travis-ci = { repository = "quininer/tokio-rustls" }
 appveyor = { repository = "quininer/tokio-rustls" }
 
 [dependencies]
-tokio = { version = "0.1.6", optional = true }
+futures = { version = "0.1", optional = true }
+tokio-io = { version = "0.1.6", optional = true }
 bytes = { version = "0.4", optional = true }
 iovec = { version = "0.1", optional = true }
 rustls = "0.14"
@@ -28,4 +29,4 @@ lazy_static = "1"
 [features]
 default = ["tokio-support"]
 nightly = ["bytes", "iovec"]
-tokio-support = ["tokio"]
+tokio-support = ["futures", "tokio-io"]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,7 +10,7 @@ use rustls::Session;
 use rustls::WriteV;
 #[cfg(feature = "nightly")]
 #[cfg(feature = "tokio-support")]
-use tokio::io::AsyncWrite;
+use tokio_io::AsyncWrite;
 
 
 pub struct Stream<'a, S: 'a, IO: 'a> {
@@ -91,7 +91,7 @@ impl<'a, S: Session, IO: Read + Write> WriteTls<'a, S, IO> for Stream<'a, S, IO>
 #[cfg(feature = "tokio-support")]
 impl<'a, S: Session, IO: Read + AsyncWrite> WriteTls<'a, S, IO> for Stream<'a, S, IO> {
     fn write_tls(&mut self) -> io::Result<usize> {
-        use tokio::prelude::Async;
+        use futures::Async;
         use self::vecbuf::VecBuf;
 
         struct V<'a, IO: 'a>(&'a mut IO);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ pub extern crate rustls;
 pub extern crate webpki;
 
 #[cfg(feature = "tokio-support")]
-extern crate tokio;
+extern crate futures;
+#[cfg(feature = "tokio-support")]
+extern crate tokio_io;
 #[cfg(feature = "nightly")]
 #[cfg(feature = "tokio-support")]
 extern crate bytes;

--- a/src/tokio_impl.rs
+++ b/src/tokio_impl.rs
@@ -1,7 +1,6 @@
 use super::*;
-use tokio::prelude::*;
-use tokio::io::{ AsyncRead, AsyncWrite };
-use tokio::prelude::Poll;
+use tokio_io::{ AsyncRead, AsyncWrite };
+use futures::{Async, Future, Poll};
 use common::Stream;
 
 


### PR DESCRIPTION
it turns out that tokio-rustls only requires a small portion of the tokio stack. This patch slims down the dependencies since not all clients need the full tokio stack.

If this is accepted, would it also be possible to publish a new version? Thanks so much!