### PR TITLE
Clarify the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,19 @@ cargo run -- 127.0.0.1 --cert mycert.der --key mykey.der
 
 ### License & Origin
 
-tokio-rustls is primarily distributed under the terms of both the [MIT license](LICENSE-MIT) and
-the [Apache License (Version 2.0)](LICENSE-APACHE), with portions covered by various BSD-like
-licenses.
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   http://opensource.org/licenses/MIT)
+
+at your option.
 
 This started as a fork of [tokio-tls](https://github.com/tokio-rs/tokio-tls).
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in tokio-rustls by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Before this PR, this phrasing appears to have been copied from the [rust project](https://github.com/rust-lang/rust/tree/f0fe716dbcbf2363ab8f929325d32a17e51039d0#license), but it does not appear that any of your code is BSD licensed. Also, it is a little ambigious if there are portions that are notcovered by MIT/Apache.

This patch instead draws it's phrasing from [futures-rs](https://github.com/rust-lang-nursery/futures-rs). Does this phrasing align  more with what you intended?

Finally, if you do accept this PR, would it be possible to cut a new version so that the artifacts on crates.io don't include this ambiguous phrasing?

Thanks so much!

Closes #29