### PR TITLE
Update to tokio 0.2.0-alpha.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ appveyor = { repository = "quininer/tokio-rustls" }
 
 [dependencies]
 smallvec = "0.6"
-tokio-io = "0.2.0-alpha.1"
-futures-core-preview = "0.3.0-alpha.17"
+tokio-io = "=0.2.0-alpha.4"
+futures-core-preview = "=0.3.0-alpha.18"
 rustls = "0.16"
 webpki = "0.21"
 
@@ -26,7 +26,7 @@ webpki = "0.21"
 early-data = []
 
 [dev-dependencies]
-tokio = "0.2.0-alpha.1"
-futures-util-preview = "0.3.0-alpha.17"
+tokio = "=0.2.0-alpha.4"
+futures-util-preview = "0.3.0-alpha.18"
 lazy_static = "1"
 webpki-roots = "0.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,19 @@
 //! Asynchronous TLS/SSL streams for Tokio using [Rustls](https://github.com/ctz/rustls).
 
-#![cfg_attr(test, feature(async_await))]
-
-
-mod common;
 pub mod client;
+mod common;
 pub mod server;
 
-use std::{ io, mem };
-use std::sync::Arc;
-use std::pin::Pin;
-use std::future::Future;
-use std::task::{ Poll, Context };
-use tokio_io::{ AsyncRead, AsyncWrite };
-use futures_core as futures;
-use rustls::{ ClientConfig, ClientSession, ServerConfig, ServerSession };
-use webpki::DNSNameRef;
 use common::Stream;
+use futures_core as futures;
+use rustls::{ClientConfig, ClientSession, ServerConfig, ServerSession};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::{io, mem};
+use tokio_io::{AsyncRead, AsyncWrite};
+use webpki::DNSNameRef;
 
 pub use rustls;
 pub use webpki;


### PR DESCRIPTION
This updates to the latest tokio and pins. I had to use a delay in the tests since now TcpStream::bind returns a future. Since it was just a test and this is an alpha I'm fine with it cuz I want to actually start using this 😄 

cc @quininer 