### PR TITLE
Update to tokio '0.2.0-alpha.5'.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "quininer/tokio-rustls" }
 
 [dependencies]
 smallvec = "0.6"
-tokio-io = "=0.2.0-alpha.4"
+tokio-io = "=0.2.0-alpha.5"
 futures-core-preview = "=0.3.0-alpha.18"
 rustls = "0.16"
 webpki = "0.21"
@@ -26,7 +26,7 @@ webpki = "0.21"
 early-data = []
 
 [dev-dependencies]
-tokio = "=0.2.0-alpha.4"
+tokio = "=0.2.0-alpha.5"
 futures-util-preview = "0.3.0-alpha.18"
 lazy_static = "1"
 webpki-roots = "0.17"


### PR DESCRIPTION
The examples appear to already be broken and I made no attempt to fix them in this PR, but I did test this against an update to Rocket's `async` branch to use the latest hyper and tokio alphas.