### PR TITLE
Export rustls dangerous_configuration feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ webpki = "0.21"
 
 [features]
 early-data = []
+dangerous_configuration = ["rustls/dangerous_configuration"]
 
 [dev-dependencies]
 tokio = "=0.2.0-alpha.6"


### PR DESCRIPTION
This was already done on master but not on the tokio-0.2 branch.

I don't know if you plan to rebase tokio-0.2 on master or to merge master into it at some point, but this feature can be useful.